### PR TITLE
fix(DesktopModal) fix width on storybook production env stc-128

### DIFF
--- a/src/components/DesktopModal/DesktopModal.tsx
+++ b/src/components/DesktopModal/DesktopModal.tsx
@@ -33,6 +33,7 @@ const DesktopModal = ({
           padding: "32px",
           backgroundColor: "transparent",
           height: "100vh",
+          width: "100vw",
         },
       }}
       isOpen={isVisible}


### PR DESCRIPTION
set content width to 100vw, to fix the bug found on production env.
<img width="1264" alt="Captura de Tela 2021-09-20 às 15 05 32" src="https://user-images.githubusercontent.com/18689578/134052048-6f113ed6-f559-4716-b04a-20c57c473823.png">
 
